### PR TITLE
WebSocket のサーバーとクライアントの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # Dependency directories (remove the comment below to include it)
 go.mod
+go.sum
 
 ## Yarn
 scripts/node_modules

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"html/template"
+	"log"
 	"net/http"
 )
 
@@ -10,5 +12,13 @@ func Init(mux *http.ServeMux) {
 }
 
 func playHandler(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "./website/static/html/play.html")
+	log.Printf("Host: %s", r.Host)
+	t, err := template.ParseFiles("./website/static/html/play.html")
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if err := t.Execute(w, r.Host); err != nil {
+		log.Println(err)
+	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,8 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+
+	"ReversiOnlineBattle/websocket"
 )
 
 func Init(mux *http.ServeMux) {
@@ -18,7 +20,9 @@ func playHandler(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		return
 	}
-	if err := t.Execute(w, r.Host); err != nil {
+	gameId := websocket.StartGame()
+	info := map[string]string{"host": r.Host, "gameId": gameId}
+	if err := t.Execute(w, info); err != nil {
 		log.Println(err)
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"ReversiOnlineBattle/client"
+	"ReversiOnlineBattle/websocket"
 )
 
 func main() {
@@ -15,6 +16,7 @@ func main() {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintf(w, "Hello, this is Reversi Online Battle.\nplay game => /play\n")
 	})
+	websocket.Init(mux)
 	client.Init(mux)
 	log.Fatal(http.ListenAndServe(":" + port, mux))
 }

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -19,8 +19,10 @@ RUN yarn build
 FROM golang:latest as server
 
 WORKDIR /go/src/ReversiOnlineBattle
-COPY . .
 ENV GO111MODULE on
+COPY ./go.mod  ./
+RUN go mod download
+COPY . .
 
 WORKDIR ./cmd
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o main

--- a/reversi/reversi.go
+++ b/reversi/reversi.go
@@ -5,9 +5,9 @@ type Reversi struct {
 	turn int
 }
 
-func Init() Reversi {
+func Init() *Reversi {
 	board := initBoard()
-	rv := Reversi{board, 1}
+	rv := &Reversi{board, 1}
 	return rv
 }
 

--- a/website/src/js/client.js
+++ b/website/src/js/client.js
@@ -77,7 +77,27 @@ const board = new Board([
 ])
 
 const host = document.getElementById("host").innerText
+const gameId = document.getElementById("game-id").innerText
 const ws = new WebSocket("ws://" + host + "/open")
+ws.onopen = (event) => console.log("connected.", event)
+ws.onclose = (event) => console.log("disconnected.", event)
+ws.onerror = (event) => console.log("Error: ", event)
 ws.onmessage = (event) => {
-    console.log(event.data)
+    board.updateBoard(JSON.parse(event.data))
+    turn = 3 - turn
+}
+
+let turn = 1
+
+const put = (x, y) => {
+    const data = JSON.stringify({
+        gameId: gameId,
+        turn: turn,
+        point: {
+            x: x - 1,
+            y: y - 1
+        }
+    })
+    console.log("send: ", data)
+    ws.send(data)
 }

--- a/website/src/js/client.js
+++ b/website/src/js/client.js
@@ -75,3 +75,9 @@ const board = new Board([
     [0, 0, 0, 0, 0, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, 0],
 ])
+
+const host = document.getElementById("host").innerText
+const ws = new WebSocket("ws://" + host + "/open")
+ws.onmessage = (event) => {
+    console.log(event.data)
+}

--- a/website/src/js/client.js
+++ b/website/src/js/client.js
@@ -5,6 +5,8 @@ const boardSize  = cellSize * 8 + lineWidth * 9
 const baseSize   = lineWidth + cellSize
 const diskMargin = 10
 const diskRadius = (cellSize - diskMargin) / 2
+const realSize   = Math.min(window.innerWidth * 0.8, window.innerHeight * 0.7)
+const sizeRatio  = boardSize / realSize
 
 class Board {
     constructor(board) {
@@ -65,6 +67,8 @@ class Board {
     }
 }
 
+const canvas = document.getElementById("canvas")
+
 const board = new Board([
     [0, 0, 0, 0, 0, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, 0],
@@ -87,17 +91,17 @@ ws.onmessage = (event) => {
     turn = 3 - turn
 }
 
-let turn = 1
-
-const put = (x, y) => {
+canvas.addEventListener("click", (event) => {
     const data = JSON.stringify({
         gameId: gameId,
         turn: turn,
         point: {
-            x: x - 1,
-            y: y - 1
+            x: Math.floor((event.clientX - canvas.offsetLeft) / baseSize * sizeRatio),
+            y: Math.floor((event.clientY - canvas.offsetTop) / baseSize * sizeRatio)
         }
     })
     console.log("send: ", data)
     ws.send(data)
-}
+})
+
+let turn = 1

--- a/website/src/pug/play.pug
+++ b/website/src/pug/play.pug
@@ -11,5 +11,7 @@ html(lang="ja")
         h1.title Reversi Online Battle
         div.board
             canvas#canvas(width=818 height=818)
-        span#host {{.}}
+        div.info
+            p#host {{.host}}
+            p#game-id {{.gameId}}
         script(src="resources/js/client.js")

--- a/website/src/pug/play.pug
+++ b/website/src/pug/play.pug
@@ -11,4 +11,5 @@ html(lang="ja")
         h1.title Reversi Online Battle
         div.board
             canvas#canvas(width=818 height=818)
+        span#host {{.}}
         script(src="resources/js/client.js")

--- a/website/src/sass/play.sass
+++ b/website/src/sass/play.sass
@@ -5,5 +5,5 @@
   width: unquote("min(80vw, 70vh)")
   height: unquote("min(80vw, 70vh)")
 
-#host
+.info
   display: none

--- a/website/src/sass/play.sass
+++ b/website/src/sass/play.sass
@@ -4,3 +4,6 @@
 #canvas
   width: unquote("min(80vw, 70vh)")
   height: unquote("min(80vw, 70vh)")
+
+#host
+  display: none

--- a/websocket/game.go
+++ b/websocket/game.go
@@ -1,0 +1,11 @@
+package websocket
+
+import "ReversiOnlineBattle/reversi"
+
+var games = make(map[string]*reversi.Reversi)
+
+func StartGame() string {
+	gameId := "test"
+	games[gameId] = reversi.Init()
+	return gameId
+}

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -2,19 +2,37 @@ package websocket
 
 import (
 	"golang.org/x/net/websocket"
-	"io"
 	"log"
 	"net/http"
 )
+
+type Data struct {
+	GameId string `json:"gameId"`
+	Turn   int    `json:"turn"`
+	Point  struct{
+		X int `json:"x"`
+		Y int `json:"Y"`
+	}             `json:"point"`
+}
 
 func Init(mux *http.ServeMux) {
 	mux.Handle("/open", websocket.Handler(open))
 }
 
-func open(conn *websocket.Conn) {
-	n, err := io.Copy(conn, conn)
-	log.Println(n)
-	if err != nil {
-		log.Println(err)
+func open(ws *websocket.Conn) {
+	for {
+		var data Data
+		if err := websocket.JSON.Receive(ws, &data); err != nil {
+			log.Printf("recieve data: %+v\n", data)
+			log.Println(err)
+			continue
+		}
+		log.Printf("recieve: %+v\n", data)
+		reversi := games[data.GameId]
+		if reversi.Put(data.Turn, data.Point.X, data.Point.Y) {
+			if err := websocket.JSON.Send(ws, reversi.Board); err != nil {
+				log.Println(err)
+			}
+		}
 	}
 }

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -1,0 +1,20 @@
+package websocket
+
+import (
+	"golang.org/x/net/websocket"
+	"io"
+	"log"
+	"net/http"
+)
+
+func Init(mux *http.ServeMux) {
+	mux.Handle("/open", websocket.Handler(open))
+}
+
+func open(conn *websocket.Conn) {
+	n, err := io.Copy(conn, conn)
+	log.Println(n)
+	if err != nil {
+		log.Println(err)
+	}
+}


### PR DESCRIPTION
サーバーとクライアントの通信に WebSocket を導入しました。
クライアントがどこに石を置くかの情報をサーバーに送信すると、サーバーはその情報を元に盤面を更新し、クライアントに返します。
クライアントでは受け取った盤面を描画し、盤面のマスをクリックすることでその場所に石を置くというメッセージをサーバーに送信します。

微妙に不具合的なものを確認しています。
・置けるはずのところに置けない → これはサーバー側のリバーシのロジックのミスだと思われます。
・サーバーが勝手にEOFメッセージを受信し続けてログが暴走する → この原因はわかっていません。