### PR TITLE
WebSocket サーバーの不具合を解消

### DIFF
--- a/websocket/server.go
+++ b/websocket/server.go
@@ -25,10 +25,13 @@ func open(ws *websocket.Conn) {
 		if err := websocket.JSON.Receive(ws, &data); err != nil {
 			log.Printf("recieve data: %+v\n", data)
 			log.Println(err)
-			continue
+			break
 		}
 		log.Printf("recieve: %+v\n", data)
-		reversi := games[data.GameId]
+		reversi, ok := games[data.GameId]
+		if !ok {
+			break
+		}
 		if reversi.Put(data.Turn, data.Point.X, data.Point.Y) {
 			if err := websocket.JSON.Send(ws, reversi.Board); err != nil {
 				log.Println(err)


### PR DESCRIPTION
想定する形式外のメッセージを受信した時に、for文を continue すると無限ループになってしまっていたので、ここを break としました。
これによりエラー発生時に socket 接続が切れることになりますが、現状これが発生するのは、通常のクライアント操作においてはページ遷移の時のみであったので、このような措置としました。

あらゆる状況に対応するためにはより適切な対処を行う必要があると思いますが、今回はこれ以上の対応は難しいので、余裕がある時、もしくはさらなる措置が必要になったタイミングで改善することにします。