### PR TITLE
リバーシのロジックの変更

### DIFF
--- a/reversi/board.go
+++ b/reversi/board.go
@@ -1,21 +1,37 @@
 package reversi
 
-import "fmt"
+import (
+	"fmt"
+)
 
-type Board [8][8]int
+type Board [10][10]int
 
 func initBoard() Board {
-	rv := Board{}
-	rv[3][3] = 2
-	rv[3][4] = 1
-	rv[4][3] = 1
-	rv[4][4] = 2
-	rv.show()
-	return rv
+	b := Board{}
+	for i := 0; i < 10; i++ {
+		b[0][i] = -1
+		b[9][i] = -1
+		b[i][0] = -1
+		b[i][9] = -1
+	}
+	b[4][4] = 2
+	b[4][5] = 1
+	b[5][4] = 1
+	b[5][5] = 2
+	b.show()
+	return b
+}
+
+func (b Board) board() (board [][]int) {
+	board = make([][]int, 8)
+	for i := 0; i < 8; i++ {
+		board[i] = b[i + 1][1:9]
+	}
+	return
 }
 
 func (b Board) show() {
-	for _, row := range b {
+	for _, row := range b.board() {
 		fmt.Println(row)
 	}
 }

--- a/reversi/board.go
+++ b/reversi/board.go
@@ -40,51 +40,42 @@ func (b *Board) put(t, x, y int) bool {
 	if b[y][x] != 0 {
 		return false
 	}
-	if !b.reverse(t, x, y) {
-		return false
-	}
-	b[y][x] = t
-	//fmt.Printf("(%d, %d) <- %d\n", x, y, t)
-	b.show()
-	return true
-}
-
-func (b *Board) reverse(t, x, y int) bool {
-	c := 0
-	for dy := -1; dy <= 1; dy += 1 {
-		for dx := -1; dx <= 1; dx += 1 {
+	for dy := -1; dy <= 1; dy++ {
+		for dx := -1; dx <= 1; dx++ {
 			if dx == 0 && dy == 0 {
 				continue
 			}
-			n := b.search(t, x + dx, y + dy, dx, dy)
-			if n > 1 {
-				c += n - 1
+			n := b.search(t, x, y, dx, dy)
+			if n == 0 {
+				continue
 			}
+			b.reverse(t, x, y, dx, dy, n + 1)
 		}
 	}
-	//fmt.Printf("c = %d\n", c)
-	return c > 0
+	b.show()
+	return b[y][x] == t
 }
 
 func (b *Board) search(t, x, y, dx, dy int) int {
-	//fmt.Printf("searching (%d, %d)\n", x, y)
-	if x + dx < 0 || x + dx > 7 || y + dy < 0 || y + dy > 7 {
+	//log.Printf("searching for (%d, %d) for (%d, %d)...\n", x, y, dx, dy)
+	n := 0
+	for b[y + dy][x + dx] == 3 - t {
+		x += dx
+		y += dy
+		n += 1
+		//log.Printf("  b[%d][%d] = %d (n = %d)", x, y, b[y][x], n)
+	}
+	if b[y + dy][x + dx] == t {
+		//log.Printf("  b[%d][%d] = %d (n = %d): returned", x + dx, y + dy, b[y + dy][x + dx], n)
+		return n
+	} else {
+		//log.Printf("  b[%d][%d] = %d (n = %d): returned", x + dx, y + dy, b[y + dy][x + dx], 0)
 		return 0
 	}
-	switch b[y][x] {
-	case 0:
-		return 0
-	case t:
-		return 1
-	case 3 - t:
-		n := b.search(t, x + dx, y + dy, dx, dy)
-		if n == 0 {
-			return 0
-		}
-		b[y][x] = t
-		//fmt.Printf("(%d, %d) <- %d\n", x, y, t)
-		return n + 1
-	default:
-		return 0
+}
+
+func (b *Board) reverse(t, x, y, dx, dy, n int) {
+	for i := 0; i < n; i++ {
+		b[y + dy * i][x + dx * i] = t
 	}
 }

--- a/reversi/reversi.go
+++ b/reversi/reversi.go
@@ -21,3 +21,7 @@ func (rv *Reversi) Put(t, x, y int) bool {
 	rv.turn = 3 - rv.turn
 	return true
 }
+
+func (rv Reversi) BoardInfo() [][]int {
+	return rv.Board.board()
+}

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -32,8 +32,8 @@ func open(ws *websocket.Conn) {
 		if !ok {
 			break
 		}
-		if reversi.Put(data.Turn, data.Point.X, data.Point.Y) {
-			if err := websocket.JSON.Send(ws, reversi.Board); err != nil {
+		if reversi.Put(data.Turn, data.Point.X + 1, data.Point.Y + 1) {
+			if err := websocket.JSON.Send(ws, reversi.BoardInfo()); err != nil {
 				log.Println(err)
 			}
 		}


### PR DESCRIPTION
リバーシのひっくり返す処理のロジックを変更しました。
元々再帰関数で、行きで探して帰りにひっくり返すという処理を行っていたのですが、
ひっくり返すかの判定(search関数)と実際にひっくり返す処理(reverse関数)を分けて行うようにしました。

これを実装するにあたり、処理の簡略化のために盤面のデータに縁を含めることにしました。
これに伴い、盤面の表示やクライアントとのやり取りの方法に変更があります。