### PR TITLE
そのターンにおける場所をサジェストする機能を追加

### DIFF
--- a/reversi/board.go
+++ b/reversi/board.go
@@ -18,7 +18,6 @@ func initBoard() Board {
 	b[4][5] = 1
 	b[5][4] = 1
 	b[5][5] = 2
-	b.show()
 	return b
 }
 
@@ -37,14 +36,11 @@ func (b Board) show() {
 }
 
 func (b *Board) put(t, x, y int) bool {
-	if b[y][x] != 0 {
+	if b[y][x] != 3 {
 		return false
 	}
 	for dy := -1; dy <= 1; dy++ {
 		for dx := -1; dx <= 1; dx++ {
-			if dx == 0 && dy == 0 {
-				continue
-			}
 			n := b.search(t, x, y, dx, dy)
 			if n == 0 {
 				continue
@@ -52,11 +48,13 @@ func (b *Board) put(t, x, y int) bool {
 			b.reverse(t, x, y, dx, dy, n + 1)
 		}
 	}
-	b.show()
 	return b[y][x] == t
 }
 
-func (b *Board) search(t, x, y, dx, dy int) int {
+func (b Board) search(t, x, y, dx, dy int) int {
+	if dx == 0 && dy == 0 {
+		return 0
+	}
 	//log.Printf("searching for (%d, %d) for (%d, %d)...\n", x, y, dx, dy)
 	n := 0
 	for b[y + dy][x + dx] == 3 - t {
@@ -78,4 +76,35 @@ func (b *Board) reverse(t, x, y, dx, dy, n int) {
 	for i := 0; i < n; i++ {
 		b[y + dy * i][x + dx * i] = t
 	}
+}
+
+func (b *Board) suggest(t int) bool {
+	flag := false
+	for y := 1; y < 9; y++ {
+		for x := 1; x < 9; x++ {
+			if b[y][x] == 1 || b[y][x] == 2 {
+				continue
+			}
+			if b.searchAllDirections(t, x, y) {
+				b[y][x] = 3
+				flag = true
+			} else {
+				b[y][x] = 0
+			}
+		}
+	}
+	return flag
+}
+
+func (b Board) searchAllDirections(t, x, y int) bool {
+	for dy := -1; dy <= 1; dy++ {
+		for dx := -1; dx <= 1; dx++ {
+			if b.search(t, x, y, dx, dy) > 0 {
+				//log.Printf("(%d, %d) can reverse", x, y)
+				return true
+			}
+		}
+	}
+	//log.Printf("(%d, %d) can not reverse", x, y)
+	return false
 }

--- a/reversi/reversi.go
+++ b/reversi/reversi.go
@@ -7,7 +7,9 @@ type Reversi struct {
 
 func Init() *Reversi {
 	board := initBoard()
+	board.suggest(1)
 	rv := &Reversi{board, 1}
+	rv.show()
 	return rv
 }
 
@@ -19,6 +21,8 @@ func (rv *Reversi) Put(t, x, y int) bool {
 		return false
 	}
 	rv.turn = 3 - rv.turn
+	rv.Board.suggest(rv.turn)
+	rv.show()
 	return true
 }
 

--- a/website/src/js/client.js
+++ b/website/src/js/client.js
@@ -1,10 +1,12 @@
 const p2 = Math.PI * 2
-const lineWidth  = 2
-const cellSize   = 100
-const boardSize  = cellSize * 8 + lineWidth * 9
-const baseSize   = lineWidth + cellSize
-const diskMargin = 10
-const diskRadius = (cellSize - diskMargin) / 2
+const lineWidth     = 2
+const cellSize      = 100
+const boardSize     = cellSize * 8 + lineWidth * 9
+const baseSize      = lineWidth + cellSize
+const diskMargin    = 10
+const diskRadius    = cellSize / 2 - diskMargin
+const suggestMargin = 40
+const suggestRadius = cellSize / 2 - suggestMargin
 const realSize   = Math.min(window.innerWidth * 0.8, window.innerHeight * 0.7)
 const sizeRatio  = boardSize / realSize
 
@@ -45,12 +47,19 @@ class Board {
     }
 
     putDisk(x, y, c) {
+        let radius
         switch (c) {
             case 1:
                 this.ctx.fillStyle = "black"
+                radius = diskRadius
                 break
             case 2:
                 this.ctx.fillStyle = "white"
+                radius = diskRadius
+                break
+            case 3:
+                this.ctx.fillStyle = "gray"
+                radius = suggestRadius
                 break
             default:
                 return
@@ -60,8 +69,8 @@ class Board {
         const centerX = left + cellSize / 2
         const centerY = top + cellSize / 2
         this.ctx.beginPath()
-        this.ctx.moveTo(centerX + diskRadius, centerY)
-        this.ctx.arc(centerX, centerY, diskRadius, 0, p2, true)
+        this.ctx.moveTo(centerX + radius, centerY)
+        this.ctx.arc(centerX, centerY, radius, 0, p2, true)
         this.ctx.closePath()
         this.ctx.fill()
     }
@@ -72,10 +81,10 @@ const canvas = document.getElementById("canvas")
 const board = new Board([
     [0, 0, 0, 0, 0, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 2, 1, 0, 0, 0],
-    [0, 0, 0, 1, 2, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 3, 0, 0, 0, 0],
+    [0, 0, 3, 2, 1, 0, 0, 0],
+    [0, 0, 0, 1, 2, 3, 0, 0],
+    [0, 0, 0, 0, 3, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, 0],
 ])


### PR DESCRIPTION
そのターンに置くことができる (= ひっくり返すことができる) 位置をサジェストする機能を追加しました。
具体的には、各マスに対してひっくり返すことができる枚数を数え、1枚以上であればサジェストを表す 3 を置きます。
クライアント側では、3 のマスに対しては小さいグレーの丸を表示するようにしました。