### PR TITLE
サーバーがクライアントに送るメッセージのフォーマットを変更

### DIFF
--- a/reversi/reversi.go
+++ b/reversi/reversi.go
@@ -5,6 +5,13 @@ type Reversi struct {
 	turn int
 }
 
+type PutResult string
+
+const (
+	InvalidPut PutResult = "invalid_put"
+	TurnChange PutResult = "turn_change"
+)
+
 func Init() *Reversi {
 	board := initBoard()
 	board.suggest(1)
@@ -13,17 +20,17 @@ func Init() *Reversi {
 	return rv
 }
 
-func (rv *Reversi) Put(t, x, y int) bool {
+func (rv *Reversi) Put(t, x, y int) PutResult {
 	if t != rv.turn {
-		return false
+		return InvalidPut
 	}
 	if !rv.Board.put(t, x, y) {
-		return false
+		return InvalidPut
 	}
 	rv.turn = 3 - rv.turn
 	rv.Board.suggest(rv.turn)
 	rv.show()
-	return true
+	return TurnChange
 }
 
 func (rv Reversi) BoardInfo() [][]int {

--- a/website/src/js/client.js
+++ b/website/src/js/client.js
@@ -96,8 +96,12 @@ ws.onopen = (event) => console.log("connected.", event)
 ws.onclose = (event) => console.log("disconnected.", event)
 ws.onerror = (event) => console.log("Error: ", event)
 ws.onmessage = (event) => {
-    board.updateBoard(JSON.parse(event.data))
-    turn = 3 - turn
+    const msg = JSON.parse(event.data)
+    switch (msg.type) {
+        case "board":
+            board.updateBoard(msg.data)
+            turn = 3 - turn
+    }
 }
 
 canvas.addEventListener("click", (event) => {

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -4,6 +4,8 @@ import (
 	"golang.org/x/net/websocket"
 	"log"
 	"net/http"
+
+	"ReversiOnlineBattle/reversi"
 )
 
 type Data struct {
@@ -13,6 +15,11 @@ type Data struct {
 		X int `json:"x"`
 		Y int `json:"Y"`
 	}             `json:"point"`
+}
+
+type SendMessage struct {
+	Type string      `json:"type"`
+	Data interface{} `json:"data,omitempty"`
 }
 
 func Init(mux *http.ServeMux) {
@@ -28,12 +35,16 @@ func open(ws *websocket.Conn) {
 			break
 		}
 		log.Printf("recieve: %+v\n", data)
-		reversi, ok := games[data.GameId]
+		rv, ok := games[data.GameId]
 		if !ok {
 			break
 		}
-		if reversi.Put(data.Turn, data.Point.X + 1, data.Point.Y + 1) {
-			if err := websocket.JSON.Send(ws, reversi.BoardInfo()); err != nil {
+		if rv.Put(data.Turn, data.Point.X + 1, data.Point.Y + 1) == reversi.TurnChange {
+			msg := SendMessage{
+				Type:  "board",
+				Data: rv.BoardInfo(),
+			}
+			if err := websocket.JSON.Send(ws, msg); err != nil {
 				log.Println(err)
 			}
 		}


### PR DESCRIPTION
サーバーからクライアントに送るメッセージのフォーマットを変更しました。
これにより、サーバーからクライアントへ様々な指示が出せるようになります。
具体的には、ターンのパスやゲームの終了などの指示を今後追加します。